### PR TITLE
@dimroc => a few tiny fixes in the RSpec session

### DIFF
--- a/lectures/05-rspec/5.1-rspec-refactor.md
+++ b/lectures/05-rspec/5.1-rspec-refactor.md
@@ -18,7 +18,7 @@ Test First?
 Test and Behavior Driven Development
 ------------------------------------
 
-TDD is not about testing, it's about *design*. The process is often called *Red => Green => Refactor*. 
+TDD is not about testing, it's about *design*. The process is often called *Red => Green => Refactor*.
 
 1. Write failing tests.
 2. Implement the feature, making tests pass.
@@ -35,37 +35,24 @@ Behavior-driven testing is an effective way of testing that helps developers und
 RSpec
 -----
 
-[RSpec](http://relishapp.com/rspec) is a Behavior-Driven Development tool for Ruby programmers. 
+[RSpec](http://relishapp.com/rspec) is a Behavior-Driven Development tool for Ruby programmers.
+Compare a unit test with an RSpec example.
 
 ``` ruby
 # Unit Test
 class DuckTest < ActiveSupport::TestCase
   test "quack" do
-    assert Duck.new.quack
-  end
-end
-
-# RSpec Scenario
-describe Duck
-  let(:duck) { Duck.new }
-  it "should quack" do
-    duck.quack.should be_true
+    assert Duck.new.responds_to?(:quack)
   end
 end
 ```
 
-If quacking were common, we could even write `duck.should quack`.
-
-``` ruby
+```
+# RSpec Scenario
 describe Duck
   let(:duck) { Duck.new }
-  context "in the water" do
-    before(:each) do
-      duck.swim
-    end
-    it "should quack" do
-      duck.should quack
-    end
+  it "should quack" do
+    duck.should.respond_to :quack
   end
 end
 ```
@@ -287,7 +274,7 @@ Another way of specifying `:driver => :selenium` is `:js => true`.
 Refactor in Confidence
 ----------------------
 
-Controllers support filters that avoid copy-pasting. This is called *DRYing* a controller. *DRY* stands for *Don't Repeat Yourself*. Now that we have specs that cover the application, we can refactor in confidence. 
+Controllers support filters that avoid copy-pasting. This is called *DRYing* a controller. *DRY* stands for *Don't Repeat Yourself*. Now that we have specs that cover the application, we can refactor in confidence.
 
 ``` ruby
 class ThingsController < ApplicationController
@@ -313,7 +300,7 @@ Extend the application with authentication by using the [devise gem](https://git
 RSpec Output
 ------------
 
-Create *.rspec* 
+Create *.rspec*
 
     --format nested
     --color

--- a/lectures/05-rspec/5.1-rspec-refactor.md
+++ b/lectures/05-rspec/5.1-rspec-refactor.md
@@ -52,7 +52,7 @@ end
 describe Duck
   let(:duck) { Duck.new }
   it "should quack" do
-    duck.should.respond_to :quack
+    duck.should respond_to :quack
   end
 end
 ```

--- a/lectures/05-rspec/5.1-rspec-refactor.md
+++ b/lectures/05-rspec/5.1-rspec-refactor.md
@@ -39,9 +39,9 @@ RSpec
 
 ``` ruby
 # Unit Test
-class DuckTest
+class DuckTest < ActiveSupport::TestCase
   test "quack" do
-    assert_true Duck.new.quack
+    assert Duck.new.quack
   end
 end
 
@@ -54,7 +54,7 @@ describe Duck
 end
 ```
 
-If quacking were common, we could even write `duck.should_quack`.
+If quacking were common, we could even write `duck.should quack`.
 
 ``` ruby
 describe Duck
@@ -64,7 +64,7 @@ describe Duck
       duck.swim
     end
     it "should quack" do
-      duck.quack.should be_true
+      duck.should quack
     end
   end
 end


### PR DESCRIPTION
The unit tests must inherit from `ActiveSupport::TestCase` and `assert_true` isn't defined by default, it's `assert`.
